### PR TITLE
feat(auth): scaffold login/register endpoints and fix dev API routing

### DIFF
--- a/api/AuthLogin.cs
+++ b/api/AuthLogin.cs
@@ -1,0 +1,23 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Text.Json;
+
+namespace api;
+
+public class AuthLogin
+{
+    [Function("AuthLogin")]
+    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    {
+        var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json");
+
+        // Async read of request body
+        var requestBody = await req.ReadAsStringAsync();
+
+        // Just echo back the request body for now
+        await response.WriteStringAsync(JsonSerializer.Serialize(new { message = "login endpoint hit", body = requestBody }));
+
+        return response;
+    }
+}

--- a/api/AuthRegister.cs
+++ b/api/AuthRegister.cs
@@ -1,0 +1,23 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Text.Json;
+
+namespace api;
+
+public class AuthRegister
+{
+    [Function("AuthRegister")]
+    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    {
+        var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json");
+
+        // Async read of request body
+        var requestBody = await req.ReadAsStringAsync();
+
+        // Just echo back the request body for now
+        await response.WriteStringAsync(JsonSerializer.Serialize(new { message = "register endpoint hit", body = requestBody }));
+
+        return response;
+    }
+}

--- a/app/angular.json
+++ b/app/angular.json
@@ -24,9 +24,7 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.css"
-            ]
+            "styles": ["src/styles.css"]
           },
           "configurations": {
             "production": {
@@ -55,12 +53,8 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "configurations": {
-            "production": {
-              "buildTarget": "app:build:production"
-            },
-            "development": {
-              "buildTarget": "app:build:development"
-            }
+            "production": { "buildTarget": "app:build:production" },
+            "development": { "buildTarget": "app:build:development" }
           },
           "defaultConfiguration": "development"
         },

--- a/app/src/app/pages/login/login.html
+++ b/app/src/app/pages/login/login.html
@@ -2,7 +2,7 @@
 <h2>Login</h2>
 
 <form (ngSubmit)="submit()">
-  <input type="email" [(ngModel)]="email" name="email" placeholder="Email" />
+  <input type="text" [(ngModel)]="username" name="username" placeholder="Username">
   <input type="password" [(ngModel)]="password" name="password" placeholder="Password" />
   <button type="submit">Login</button>
 </form>

--- a/app/src/app/pages/login/login.ts
+++ b/app/src/app/pages/login/login.ts
@@ -10,15 +10,14 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './login.css',
 })
 export class Login {
-  email = '';
+  username = '';
   password = '';
 
   constructor(private auth: Auth) {}
 
   submit() {
-    this.auth.login({ email: this.email, password: this.password }).subscribe({
-      next: (res) => console.log('Logged in:', res),
-      error: (err) => console.error(err),
+    this.auth.login(this.username, this.password).subscribe(res => {
+      console.log('Login response:', res);
     });
   }
 }

--- a/app/src/app/pages/register/register.html
+++ b/app/src/app/pages/register/register.html
@@ -1,7 +1,7 @@
 <h2>Register</h2>
 
 <form (ngSubmit)="submit()">
-  <input type="email" [(ngModel)]="email" name="email" placeholder="Email" />
+  <input type="text" [(ngModel)]="username" name="username" placeholder="Username">
   <input type="password" [(ngModel)]="password" name="password" placeholder="Password" />
   <button type="submit">Register</button>
 </form>

--- a/app/src/app/pages/register/register.ts
+++ b/app/src/app/pages/register/register.ts
@@ -10,15 +10,14 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './register.css',
 })
 export class Register {
-  email = '';
+  username = '';
   password = '';
 
   constructor(private auth: Auth) {}
 
   submit() {
-    this.auth.register({ email: this.email, password: this.password }).subscribe({
-      next: (res) => console.log('Registered:', res),
-      error: (err) => console.error(err),
+    this.auth.register(this.username, this.password).subscribe(res => {
+      console.log('Register response:', res);
     });
   }
 }

--- a/app/src/app/services/auth.ts
+++ b/app/src/app/services/auth.ts
@@ -1,20 +1,21 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class Auth {
-  private api = '/api'; // temporary
+  private baseUrl = `${environment.apiBaseUrl}`;
 
   constructor(private http: HttpClient) {}
 
-  register(data: { email: string; password: string }): Observable<any> {
-    return this.http.post(`${this.api}/register`, data);
+  register(username: string, password: string): Observable<any> {
+    return this.http.post(`${this.baseUrl}/AuthRegister`, { username, password });
   }
 
-  login(data: { email: string; password: string }): Observable<any> {
-    return this.http.post(`${this.api}/login`, data);
+  login(username: string, password: string): Observable<any> {
+    return this.http.post(`${this.baseUrl}/AuthLogin`, { username, password });
   }
 }

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: '/api'
+};

--- a/app/src/environments/environment.ts
+++ b/app/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:7071/api'
+};


### PR DESCRIPTION
- Created minimal AuthLogin and AuthRegister Azure Function endpoints. Each endpoint echoes request body for initial testing.
- Wired Angular login/register pages to call the local endpoints.
- Fixed development environment routing: Angular dev server proxy was not properly forwarding requests to Azure Functions on port 7071. Added environment-specific API base URL and updated services to correctly target local functions during development.
- Ensures Angular can communicate with local functions without hitting 404/500 errors caused by missing proxy configuration.